### PR TITLE
Excel Exporter wuth column group export all the colum label without check if is rendered or exportable.

### DIFF
--- a/src/main/java/org/primefaces/extensions/component/exporter/ExcelExporter.java
+++ b/src/main/java/org/primefaces/extensions/component/exporter/ExcelExporter.java
@@ -502,6 +502,9 @@ public class ExcelExporter extends Exporter {
                     int i = 0;
                     for (UIComponent rowComponent : row.getChildren()) {
                         UIColumn column = (UIColumn) rowComponent;
+                        if(!column.isExportable()||!column.isRendered()){
+                        	continue;
+                        }
                         String value = null;
                         if (facetType.equalsIgnoreCase("header")) {
                             value = column.getHeaderText();


### PR DESCRIPTION
Excel Exporter wuth column group export all the colum label without check if is rendered or exportable. this fix it.
